### PR TITLE
fix the undefined reference bug in the Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,14 @@ TARGETS = DECIDE test
 
 CFLAGS += -std=c99
 CFLAGS += -g -lstdc++
-CFLAGS += -Wall -l -L -pedantic -lm
+CFLAGS += -Wall -pedantic -lm
 
 all:: $(TARGETS)
 
 DECIDE: launch.c decide.h LICs.c CMV.c FUV.c PUM.c 
-	gcc launch.c decide.h LICs.c CMV.c FUV.c PUM.c 
+	gcc launch.c decide.h LICs.c CMV.c FUV.c PUM.c -o launch $(CFLAGS)
 test: tests.c decide.h LICs.c
-	gcc tests.c decide.h LICs.c -lm
+	gcc tests.c decide.h LICs.c -o test $(CFLAGS)
 
 
 clean:


### PR DESCRIPTION
- Added the missing $(CFLAGS) to the end of both launch and test (to the end because linked libraries like -lm (the math library) need to appear on the gcc command after the file that utilizes them)
- Modified output file names to be launch (for the main program) and test (for the test program)
- Removed the -l and -L terms found in the CFLAGS, as they didn't link to anything. (Correct me if I am wrong on this one)
- Finally I have a question, why is -lstdc++ in the list of CFLAGS, when we are only using C not C++?