### PR TITLE
fix: add LIC info to fail msg

### DIFF
--- a/tests/lic_tests.c
+++ b/tests/lic_tests.c
@@ -62,7 +62,7 @@ static char * test_lic0_positive(){
     X[0]=1; X[1]=2; X[2]=3; X[3]=12; X[4]=17;
     Y[0]=1; Y[1]=2; Y[2]=3; Y[3]=12; Y[4]=22;
 
-    mu_assert("The positive test failed!", check_lic_0() == true);
+    mu_assert("The positive test for LIC 0 failed!", check_lic_0() == true);
     return 0;
 }
 
@@ -80,7 +80,7 @@ static char * test_lic0_negative(){
     X[0]=1; X[1]=2; X[2]=3; X[3]=4; X[4]=5;
     Y[0]=1; Y[1]=2; Y[2]=3; Y[3]=4; Y[4]=6;
 
-    mu_assert("The negative test failed!", check_lic_0() == false);
+    mu_assert("The negative test for LIC 0 failed!", check_lic_0() == false);
     return 0;
 }
 
@@ -93,7 +93,7 @@ static char * test_lic0_invalid(){
     PARAMETERS.LENGTH1 = 1;
     X = NULL;
     Y = NULL;
-    mu_assert("The invalid test failed!", check_lic_0() == false);
+    mu_assert("The invalid test for LIC 0 failed!", check_lic_0() == false);
     return 0;
 }
 
@@ -111,7 +111,7 @@ static char * test_lic1_positive(){
     X[0]=1; X[1]=2; X[2]=3; X[3]=12; X[4]=17;
     Y[0]=1; Y[1]=2; Y[2]=3; Y[3]=12; Y[4]=22;
 
-    mu_assert("The positive test failed!", check_lic_1() == true);
+    mu_assert("The positive test for LIC 1 failed!", check_lic_1() == true);
     return 0;
 }
 
@@ -129,7 +129,7 @@ static char * test_lic1_negative(){
     X[0]=1; X[1]=2; X[2]=3; X[3]=4; X[4]=5;
     Y[0]=1; Y[1]=2; Y[2]=3; Y[3]=4; Y[4]=6;
 
-    mu_assert("The negative test failed!", check_lic_1() == false);
+    mu_assert("The negative test for LIC 1 failed!", check_lic_1() == false);
     return 0;
 }
 
@@ -147,7 +147,7 @@ static char * test_lic1_invalid(){
     X[0]=1; X[1]=2; X[2]=3; X[3]=4; X[4]=5;
     Y[0]=1; Y[1]=2; Y[2]=3; Y[3]=4; Y[4]=6;
     
-    mu_assert("The invalid test failed!", check_lic_1() == false);
+    mu_assert("The invalid test for LIC 1 failed!", check_lic_1() == false);
     return 0;
 } 
 
@@ -165,7 +165,7 @@ static char * test_lic2_positive(){
     X[0]=1; X[1]=2; X[2]=1; X[3]=4; X[4]=5; X[5]=6;
     Y[0]=1; Y[1]=2; Y[2]=2; Y[3]=4; Y[4]=5; Y[5]=6;
 
-    mu_assert("The positive test failed!", check_lic_2() == true);
+    mu_assert("Positive test no. 1 for LIC 2 failed!", check_lic_2() == true);
 
     NUMPOINTS = 3;
     double local_X1[NUMPOINTS];
@@ -174,7 +174,7 @@ static char * test_lic2_positive(){
     Y = local_Y1;
     X[0]=4; X[1]=6; X[2]=5;
     Y[0]=4; Y[1]=6; Y[2]=5;
-    mu_assert("The positive test failed!", check_lic_2() == true);
+    mu_assert("Positive test no. 2 for LIC 2 failed!", check_lic_2() == true);
   
 
     NUMPOINTS = 3;
@@ -186,7 +186,7 @@ static char * test_lic2_positive(){
     X[0]=1; X[1]=2; X[2]=2;
     Y[0]=1; Y[1]=2; Y[2]=1;
 
-    mu_assert("The positive test failed!", check_lic_2() == true);
+    mu_assert("Positive test no. 3 for LIC 2 failed!", check_lic_2() == true);
     return 0;
 }
 
@@ -203,7 +203,7 @@ static char * test_lic2_negative(){
     Y = local_Y;
     X[0]=4; X[1]=6; X[2]=5;
     Y[0]=4; Y[1]=6; Y[2]=5;
-    mu_assert("The negative test failed!", check_lic_2() == false);
+    mu_assert("Negative test no. 1 for LIC 2 failed!", check_lic_2() == false);
 
     NUMPOINTS = 3;
     PARAMETERS.EPSILON = PI/2;
@@ -213,7 +213,7 @@ static char * test_lic2_negative(){
     Y = local_Y1;
     X[0]=4; X[1]=4; X[2]=5;
     Y[0]=4; Y[1]=4; Y[2]=5;
-    mu_assert("The negative test failed!", check_lic_2() == false);
+    mu_assert("Negative test no. 2 for LIC 2 failed!", check_lic_2() == false);
     return 0;
 
 }
@@ -231,7 +231,7 @@ static char * test_lic2_invalid(){
     Y = local_Y;
     X = NULL;
     Y = NULL;
-    mu_assert("The invalid test failed!", check_lic_2() == false);
+    mu_assert("Invalid test no. 1 for LIC 2 failed!", check_lic_2() == false);
 
     NUMPOINTS = 3;
     PARAMETERS.EPSILON = PI;
@@ -241,7 +241,7 @@ static char * test_lic2_invalid(){
     Y = local_Y1;
     X[0]=1; X[1]=2; X[2]=2;
     Y[0]=1; Y[1]=2; Y[2]=1;
-    mu_assert("The invalid test failed!", check_lic_2() == false);
+    mu_assert("Invalid test no. 2 for LIC 2 failed!", check_lic_2() == false);
 
     NUMPOINTS = 1;
     PARAMETERS.EPSILON = PI;
@@ -249,7 +249,7 @@ static char * test_lic2_invalid(){
     double local_Y2[NUMPOINTS];
     X = local_X2;
     Y = local_Y2;
-    mu_assert("The invalid test failed!", check_lic_2() == false);
+    mu_assert("Invalid test no. 3 for LIC 2 failed!", check_lic_2() == false);
     return 0;
 }
 


### PR DESCRIPTION
Fixes #88 . Added LIC info to all tests as this was missing from some outputs. Also the negative test for LIC 1 fails (and this was before my change as I changed it because it didn't tell me which test failed).